### PR TITLE
FringeTask: fix confusion between mask plane and mask bit

### DIFF
--- a/python/lsst/pipe/drivers/constructCalibs.py
+++ b/python/lsst/pipe/drivers/constructCalibs.py
@@ -854,7 +854,7 @@ class FringeTask(CalibTask):
         mi /= bgLevel
         footprintSets = self.detection.detectFootprints(exposure, sigma=self.config.detectSigma)
         mask = exposure.getMaskedImage().getMask()
-        detected = mask.addMaskPlane("DETECTED")
+        detected = 1 << mask.addMaskPlane("DETECTED")
         for fpSet in (footprintSets.positive, footprintSets.negative):
             if fpSet is not None:
                 afwDet.setMaskFromFootprintList(mask, fpSet.getFootprints(), detected)


### PR DESCRIPTION
setMaskFromFootprintList wants a mask bit, but we have been giving
it a mask plane.

Thanks to Michitaro Koike for discovering and fixing this bug.
