### PR TITLE
DarkCombineTask: fix setting of metadata

### DIFF
--- a/python/lsst/pipe/drivers/constructCalibs.py
+++ b/python/lsst/pipe/drivers/constructCalibs.py
@@ -649,7 +649,12 @@ class DarkCombineTask(CalibCombineTask):
     """Task to combine dark images"""
     def run(*args, **kwargs):
         combined = CalibCombineTask.run(*args, **kwargs)
-        combined.getInfo().setVisitInfo(afwImage.makeVisitInfo(exposureTime=1.0, darkTime=1.0))
+
+        # Update the metadata
+        visitInfo = afwImage.makeVisitInfo(exposureTime=1.0, darkTime=1.0)
+        md = dafBase.PropertyList.cast(combined.getMetadata())
+        afwImage.setVisitInfoMetadata(md, visitInfo)
+
         return combined
 
 class DarkConfig(CalibConfig):


### PR DESCRIPTION
DM-8913 changed DarkCombineTask to use VisitInfo, but this assumed
that the combined variable is an Exposure, but it's actually a
DecoratedImage, which broke the dark creation. Fixed by using a
different means to get the metadata in.