### PR TITLE
Make location of detection configurable

### DIFF
--- a/python/lsst/pipe/drivers/coaddDriver.py
+++ b/python/lsst/pipe/drivers/coaddDriver.py
@@ -283,7 +283,7 @@ class CoaddDriverTask(BatchPoolTask):
                 detResults = self.detectCoaddSources.runDetection(coadd, idFactory)
                 self.detectCoaddSources.write(coadd, detResults, patchRef)
         else:
-            self.assembleCoadd.writeCoaddOutput(patchRef, coadd)
+            patchRef.put(coadd, self.assembleCoadd.config.coaddName+"Coadd")
 
     def selectExposures(self, patchRef, selectDataList):
         """!Select exposures to operate upon, via the SelectImagesTask

--- a/python/lsst/pipe/drivers/coaddDriver.py
+++ b/python/lsst/pipe/drivers/coaddDriver.py
@@ -1,5 +1,3 @@
-
-
 from __future__ import absolute_import, division, print_function
 
 from builtins import zip
@@ -272,6 +270,10 @@ class CoaddDriverTask(BatchPoolTask):
         if coadd is None:
             return
 
+        # The section of code below determines if the detection task should be
+        # run. If detection is run, then the products are written out as
+        # deepCoadd_calexp. If detection is not run, then the outputs of the
+        # assemble task are written out as deepCoadd.
         if self.config.doDetection:
             with self.logOperation("detection on {}".format(patchRef.dataId),
                                    catch=True):

--- a/python/lsst/pipe/drivers/multiBandDriver.py
+++ b/python/lsst/pipe/drivers/multiBandDriver.py
@@ -221,8 +221,8 @@ class MultiBandDriverTask(BatchPoolTask):
         pool.storeSet(butler=butler)
 
         detectionList = [patchRef for patchRef in patchRefList if not
-                         patchRef.dataExists(self.config.coaddName +
-                                             "Coadd_calexp")]
+                         patchRef.datasetExists(self.config.coaddName +
+                                                "Coadd_calexp")]
 
         pool.map(self.runDetection, detectionList)
 

--- a/python/lsst/pipe/drivers/multiBandDriver.py
+++ b/python/lsst/pipe/drivers/multiBandDriver.py
@@ -6,10 +6,12 @@ from builtins import zip
 
 from lsst.pex.config import Config, Field, ConfigurableField
 from lsst.pipe.base import ArgumentParser, TaskRunner
-from lsst.pipe.tasks.multiBand import (MergeDetectionsTask,
-                                       MeasureMergedCoaddSourcesTask, MergeMeasurementsTask,)
+from lsst.pipe.tasks.multiBand import (DetectCoaddSourcesTask,
+                                       MergeDetectionsTask,
+                                       MeasureMergedCoaddSourcesTask,
+                                       MergeMeasurementsTask,)
 from lsst.ctrl.pool.parallel import BatchPoolTask
-from lsst.ctrl.pool.pool import Pool, abortOnError
+from lsst.ctrl.pool.pool import Pool, abortOnError, NODE
 from lsst.meas.base.references import MultiBandReferencesTask
 from lsst.meas.base.forcedPhotCoadd import ForcedPhotCoaddTask
 from lsst.pipe.drivers.utils import getDataRef, TractDataIdContainer
@@ -68,6 +70,10 @@ class MultiBandDataIdContainer(CoaddDataIdContainer):
 
 class MultiBandDriverConfig(Config):
     coaddName = Field(dtype=str, default="deep", doc="Name of coadd")
+    doDetection = Field(dtype=bool, default=False, doc="Run detection on the "
+                        "Coadded exposure")
+    detectCoaddSources = ConfigurableField(target=DetectCoaddSourcesTask,
+                                           doc="Detect sources on coadd")
     mergeCoaddDetections = ConfigurableField(
         target=MergeDetectionsTask, doc="Merge detections")
     measureCoaddSources = ConfigurableField(target=MeasureMergedCoaddSourcesTask,
@@ -156,6 +162,8 @@ class MultiBandDriverTask(BatchPoolTask):
             schema = butler.get(self.config.coaddName +
                                 "Coadd_det_schema", immediate=True).schema
         self.butler = butler
+        if self.config.doDetection:
+            self.makeSubtask("detectCoaddSources")
         self.makeSubtask("mergeCoaddDetections", schema=schema)
         self.makeSubtask("measureCoaddSources", schema=afwTable.Schema(self.mergeCoaddDetections.schema),
                          peakSchema=afwTable.Schema(
@@ -213,7 +221,10 @@ class MultiBandDriverTask(BatchPoolTask):
             raise RuntimeError("No valid patches")
         pool = Pool("all")
         pool.cacheClear()
-        pool.storeSet(butler=butler)
+        pool.storeSet(butler=butler, coaddType=self.config.coaddName + "Coadd")
+
+        if self.config.doDetection:
+            pool.map(self.runDetection, patchRefList)
 
         patchRefList = [patchRef for patchRef in patchRefList if
                         patchRef.datasetExists(self.config.coaddName + "Coadd_calexp") and
@@ -298,6 +309,20 @@ class MultiBandDriverTask(BatchPoolTask):
                 filename = butler.get(
                     reprocessDataset + "_filename", dataId)[0]
                 os.unlink(filename)
+
+    def runDetection(self, cache, patchRef):
+        """! Run detection on a patch
+        Only slve nodes execute this method.
+
+        @param cache: Pool cache, containing butler
+        @param patchRef: Patch on which to do detection
+        """
+        with self.logOperation("do detections on {}".format(patchRef.dataId)):
+            idFactory = self.detectCoaddSources.makeIdFactory(patchRef)
+            self.log.info("%s: Reading coadd %s" % (NODE, patchRef.dataId))
+            coadd = patchRef.get(cache.coaddType, immediate=True)
+            detResults = self.detectCoaddSources.runDetection(coadd, idFactory)
+            self.detectCoaddSources.write(coadd, detResults, patchRef)
 
     def runMergeDetections(self, cache, dataIdList):
         """!Run detection merging on a patch


### PR DESCRIPTION
Make the detection task optional in both coaddDriver and
multiBandDriver. This is intended to decuple detection from
generating a coadd, such that detection and meausrement may
happen multiple times from the same input coadd. This supports
work to make inserting fake objects into a coadd possible at
the detection stage.