### PR TITLE
Fix bitrot from PyBind port

### DIFF
--- a/python/lsst/pipe/drivers/constructCalibs.py
+++ b/python/lsst/pipe/drivers/constructCalibs.py
@@ -771,7 +771,7 @@ class DarkTask(CalibTask):
                 mask = exposure.getMaskedImage().getMask().clone()
                 mask &= mask.getPlaneBitMask("CR")
                 fpSet = afwDet.FootprintSet(
-                    mask.convertU(), afwDet.Threshold(0.5))
+                    mask, afwDet.Threshold(0.5))
                 fpSet = afwDet.FootprintSet(fpSet, self.config.crGrow, True)
                 fpSet.setMask(exposure.getMaskedImage().getMask(), "CR")
 


### PR DESCRIPTION
Object of the right type is now returned by default, so no conversion necessary