### PR TITLE
DM-11136: constructCalibs: fix addMissingKeys usage

### DIFF
--- a/python/lsst/pipe/drivers/constructCalibs.py
+++ b/python/lsst/pipe/drivers/constructCalibs.py
@@ -385,6 +385,7 @@ class CalibTask(BatchPoolTask):
         outputIdItemList = list(outputId.items())
         for ccdName in ccdIdLists:
             dataId = dict([(k, ccdName[i]) for i, k in enumerate(self.config.ccdKeys)])
+            dataId.update(outputIdItemList)
             self.addMissingKeys(dataId, butler)
             dataId.update(outputIdItemList)
             
@@ -663,6 +664,7 @@ class CalibTask(BatchPoolTask):
         """
         # Check if we need to look up any keys that aren't in the output dataId
         fullOutputId = {k: struct.ccdName[i] for i, k in enumerate(self.config.ccdKeys)}
+        fullOutputId.update(outputId)
         self.addMissingKeys(fullOutputId, cache.butler)
         fullOutputId.update(outputId)  # must be after the call to queryMetadata
         outputId = fullOutputId


### PR DESCRIPTION
addMissingKeys needs something to start with, so set it to what we already
have, and then add what's missing.