### PR TITLE
DM-11917: coaddDriver: fix fallout from selection interface change

### DIFF
--- a/python/lsst/pipe/drivers/coaddDriver.py
+++ b/python/lsst/pipe/drivers/coaddDriver.py
@@ -207,18 +207,19 @@ class CoaddDriverTask(BatchPoolTask):
         @param selectDataList: List of selection data
         @return whether tract has any overlapping inputs
         """
+        def makePolygon(wcs, bbox):
+            """Return a polygon for the image, given Wcs and bounding box"""
+            return convexHull([wcs.pixelToSky(afwGeom.Point2D(coord)).getVector() for
+                               coord in bbox.getCorners()])
+
         skymap = cache.skymap
         tract = skymap[tractId]
         tractWcs = tract.getWcs()
-        tractPoly = convexHull([tractWcs.pixelToSky(afwGeom.Point2D(coord)).getVector() for
-                                coord in tract.getBBox().getCorners()])
+        tractPoly = makePolygon(tractWcs, tract.getBBox())
 
         for selectData in selectIdList:
             if not hasattr(selectData, "poly"):
-                wcs = selectData.wcs
-                box = selectData.bbox
-                selectData.poly = convexHull([wcs.pixelToSky(coord).getVector()
-                                              for coord in box.getCorners()])
+                selectData.poly = makePolygon(selectData.wcs, selectData.bbox)
             if tractPoly.intersects(selectData.poly):
                 return True
         return False


### PR DESCRIPTION
DM-11332 made small changes to the selection data (it provides a bounding
box instead of a tuple of sizes). The changes made here to adapt to those
changes weren't tested, and (unsurprisingly) didn't work: Box2I.getCorners()
produces Point2I, but Wcs.pixelToSky wants Point2D. The fix is simple: cast.
But then the line looks a lot like one earlier, so factor out the common
code.