### PR TITLE
DM-6965: multibandDriver: write metadata from detection

### DIFF
--- a/python/lsst/pipe/drivers/multiBandDriver.py
+++ b/python/lsst/pipe/drivers/multiBandDriver.py
@@ -337,8 +337,10 @@ class MultiBandDriverTask(BatchPoolTask):
             idFactory = self.detectCoaddSources.makeIdFactory(patchRef)
             coadd = patchRef.get(self.config.coaddName + "Coadd",
                                  immediate=True)
+            self.detectCoaddSources.emptyMetadata()
             detResults = self.detectCoaddSources.runDetection(coadd, idFactory)
             self.detectCoaddSources.write(coadd, detResults, patchRef)
+            self.detectCoaddSources.writeMetadata(patchRef)
 
     def runMergeDetections(self, cache, dataIdList):
         """!Run detection merging on a patch


### PR DESCRIPTION
We now put some useful information in the detection metadata, so we need
to make sure it's clean and write it out.

Not using MultiBandDriverTask.writeMetadata because the 'dataRef' that's
provided there is actually a list of data references, and it's not clear
we can identify which entry in the metadata belongs to which dataRef.