### PR TITLE
DM-12450: use --reuse-outputs-from instead of doOverwrite/clobber

### DIFF
--- a/python/lsst/pipe/drivers/coaddDriver.py
+++ b/python/lsst/pipe/drivers/coaddDriver.py
@@ -269,10 +269,10 @@ class CoaddDriverTask(BatchPoolTask):
         # detectCoaddSources outputs too, and those outputs already exist.
         canSkipDetection = (
             "detectCoaddSources" in self.reuse and
-            patchRef.datasetExists(self.detectCoaddSources.config.coaddName+"Coadd_det")
+            patchRef.datasetExists(self.detectCoaddSources.config.coaddName+"Coadd_det", write=True)
         )
         if "assembleCoadd" in self.reuse:
-            if patchRef.datasetExists(cache.coaddType):
+            if patchRef.datasetExists(cache.coaddType, write=True):
                 self.log.info("%s: Skipping assembleCoadd for %s; outputs already exist." %
                               (NODE, patchRef.dataId))
                 coadd = patchRef.get(cache.coaddType, immediate=True)

--- a/python/lsst/pipe/drivers/coaddDriver.py
+++ b/python/lsst/pipe/drivers/coaddDriver.py
@@ -75,8 +75,8 @@ class CoaddDriverTask(BatchPoolTask):
     _DefaultName = "coaddDriver"
     RunnerClass = CoaddDriverTaskRunner
 
-    def __init__(self, *args, **kwargs):
-        BatchPoolTask.__init__(self, *args, **kwargs)
+    def __init__(self, **kwargs):
+        BatchPoolTask.__init__(self, **kwargs)
         self.makeSubtask("select")
         self.makeSubtask("makeCoaddTempExp")
         self.makeSubtask("backgroundReference")

--- a/python/lsst/pipe/drivers/multiBandDriver.py
+++ b/python/lsst/pipe/drivers/multiBandDriver.py
@@ -230,7 +230,7 @@ class MultiBandDriverTask(BatchPoolTask):
         detectionList = []
         for patchRef in patchRefList:
             if ("detectCoaddSources" in self.reuse and
-                    patchRef.datasetExists(self.config.coaddName + "Coadd_calexp")):
+                    patchRef.datasetExists(self.config.coaddName + "Coadd_calexp", write=True)):
                 self.log.info("Skipping detectCoaddSources for %s; output already exists." % patchRef.dataId)
                 continue
             if patchRef.datasetExists(self.config.coaddName + "Coadd"):
@@ -354,7 +354,7 @@ class MultiBandDriverTask(BatchPoolTask):
             dataRefList = [getDataRef(cache.butler, dataId, self.config.coaddName + "Coadd_calexp") for
                            dataId in dataIdList]
             if ("mergeCoaddDetections" in self.reuse and
-                    dataRefList[0].datasetExists(self.config.coaddName + "Coadd_mergeDet")):
+                    dataRefList[0].datasetExists(self.config.coaddName + "Coadd_mergeDet", write=True)):
                 self.log.info("Skipping mergeCoaddDetections for %s; output already exists." %
                               dataRefList[0].dataId)
                 return
@@ -374,7 +374,7 @@ class MultiBandDriverTask(BatchPoolTask):
                                  self.config.coaddName + "Coadd_calexp")
             reprocessing = False  # Does this patch require reprocessing?
             if ("measureCoaddSources" in self.reuse and
-                    dataRef.datasetExists(self.config.coaddName + "Coadd_meas")):
+                    dataRef.datasetExists(self.config.coaddName + "Coadd_meas", write=True)):
                 if not self.config.reprocessing:
                     self.log.info("Skipping measureCoaddSources for %s; output already exists" % dataId)
                     return False
@@ -412,7 +412,7 @@ class MultiBandDriverTask(BatchPoolTask):
                            dataId in dataIdList]
             if ("mergeCoaddMeasurements" in self.reuse and
                 not self.config.reprocessing and
-                    dataRefList[0].datasetExists(self.config.coaddName + "Coadd_ref")):
+                    dataRefList[0].datasetExists(self.config.coaddName + "Coadd_ref", write=True)):
                 self.log.info("Skipping mergeCoaddMeasurements for %s; output already exists" %
                               dataRefList[0].dataId)
                 return
@@ -431,7 +431,7 @@ class MultiBandDriverTask(BatchPoolTask):
                                  self.config.coaddName + "Coadd_calexp")
             if ("forcedPhotCoadd" in self.reuse and
                 not self.config.reprocessing and
-                    dataRef.datasetExists(self.config.coaddName + "Coadd_forced_src")):
+                    dataRef.datasetExists(self.config.coaddName + "Coadd_forced_src", write=True)):
                 self.log.info("Skipping forcedPhotCoadd for %s; output already exists" % dataId)
                 return
             self.forcedPhotCoadd.run(dataRef)


### PR DESCRIPTION
This is a major change to the behavior of these tasks, as described in [RFC-407](https://jira.lsstcorp.org/browse/RFC-407).

The changes to `coaddDriver` are tightly coupled to related changes in `makeCoaddTempExp` in `pipe_tasks`.