### PR TITLE
DM-12766: Add __reduce__ to CoaddDriver so to know how to pickle

### DIFF
--- a/python/lsst/pipe/drivers/coaddDriver.py
+++ b/python/lsst/pipe/drivers/coaddDriver.py
@@ -97,7 +97,8 @@ class CoaddDriverTask(BatchPoolTask):
     def __reduce__(self):
         """Pickler"""
         return unpickle, (self.__class__, [], dict(config=self.config, name=self._name,
-                                                   parentTask=self._parentTask, log=self.log))
+                                                   parentTask=self._parentTask, log=self.log,
+                                                   reuse=self.reuse))
 
     @classmethod
     def _makeArgumentParser(cls, **kwargs):

--- a/python/lsst/pipe/drivers/coaddDriver.py
+++ b/python/lsst/pipe/drivers/coaddDriver.py
@@ -75,6 +75,11 @@ class CoaddDriverTaskRunner(CoaddTaskRunner):
         return [(parsedCmd.id.refList, kwargs), ]
 
 
+def unpickle(factory, args, kwargs):
+    """Unpickle something by calling a factory"""
+    return factory(*args, **kwargs)
+
+
 class CoaddDriverTask(BatchPoolTask):
     ConfigClass = CoaddDriverConfig
     _DefaultName = "coaddDriver"
@@ -88,6 +93,11 @@ class CoaddDriverTask(BatchPoolTask):
         self.makeSubtask("backgroundReference")
         self.makeSubtask("assembleCoadd")
         self.makeSubtask("detectCoaddSources")
+
+    def __reduce__(self):
+        """Pickler"""
+        return unpickle, (self.__class__, [], dict(config=self.config, name=self._name,
+                                                   parentTask=self._parentTask, log=self.log))
 
     @classmethod
     def _makeArgumentParser(cls, **kwargs):

--- a/python/lsst/pipe/drivers/multiBandDriver.py
+++ b/python/lsst/pipe/drivers/multiBandDriver.py
@@ -173,7 +173,7 @@ class MultiBandDriverTask(BatchPoolTask):
         """Pickler"""
         return unpickle, (self.__class__, [], dict(config=self.config, name=self._name,
                                                    parentTask=self._parentTask, log=self.log,
-                                                   butler=self.butler))
+                                                   butler=self.butler, reuse=self.reuse))
 
     @classmethod
     def _makeArgumentParser(cls, *args, **kwargs):


### PR DESCRIPTION
Running coaddDriver with cores >1 has been producing `MPI_Abort(MPI_COMM_WORLD, 1)`