### PR TITLE
Remove duplicate and nonexistent config defaults

### DIFF
--- a/python/lsst/pipe/drivers/coaddDriver.py
+++ b/python/lsst/pipe/drivers/coaddDriver.py
@@ -40,8 +40,6 @@ class CoaddDriverConfig(Config):
         self.makeCoaddTempExp.select.retarget(NullSelectImagesTask)
         self.assembleCoadd.select.retarget(NullSelectImagesTask)
         self.assembleCoadd.doWrite = False
-        self.assembleCoadd.doMatchBackgrounds = False
-        self.makeCoaddTempExp.bgSubtracted = True
         self.assembleCoadd.badMaskPlanes = [
             'BAD', 'EDGE', 'SAT', 'INTRP', 'NO_DATA']
 


### PR DESCRIPTION
* config `doMatchBackgrounds` removed in DM-9955
* config `bgSubtracted` already True by default