### PR TITLE
DM-12968: Remove INTERP from bad mask planes for coaddition

### DIFF
--- a/python/lsst/pipe/drivers/coaddDriver.py
+++ b/python/lsst/pipe/drivers/coaddDriver.py
@@ -41,7 +41,7 @@ class CoaddDriverConfig(Config):
         self.assembleCoadd.select.retarget(NullSelectImagesTask)
         self.assembleCoadd.doWrite = False
         self.assembleCoadd.badMaskPlanes = [
-            'BAD', 'EDGE', 'SAT', 'INTRP', 'NO_DATA']
+            'BAD', 'EDGE', 'SAT', 'NO_DATA']
 
     def validate(self):
         if self.makeCoaddTempExp.coaddName != self.coaddName:

--- a/python/lsst/pipe/drivers/coaddDriver.py
+++ b/python/lsst/pipe/drivers/coaddDriver.py
@@ -40,8 +40,6 @@ class CoaddDriverConfig(Config):
         self.makeCoaddTempExp.select.retarget(NullSelectImagesTask)
         self.assembleCoadd.select.retarget(NullSelectImagesTask)
         self.assembleCoadd.doWrite = False
-        self.assembleCoadd.badMaskPlanes = [
-            'BAD', 'EDGE', 'SAT', 'NO_DATA']
 
     def validate(self):
         if self.makeCoaddTempExp.coaddName != self.coaddName:


### PR DESCRIPTION
Interpolation is pretty good for e.g. cosmic rays, and
leaving out pixels leads to INEXACT_PSF masks on the coadd,
which we'd like to minimize.