### PR TITLE
DM-10765: Replace existing WCS classes with SkyWcs

### DIFF
--- a/python/lsst/pipe/drivers/background.py
+++ b/python/lsst/pipe/drivers/background.py
@@ -649,8 +649,8 @@ class FocalPlaneBackground(object):
         image = afwImage.ImageF(bbox.getDimensions()//self.config.binning)
         norm = afwImage.ImageF(image.getBBox())
         ctrl = afwMath.WarpingControl("bilinear")
-        afwMath.warpImage(image, focalPlane, toSample, ctrl)
-        afwMath.warpImage(norm, fpNorm, toSample, ctrl)
+        afwMath.warpImage(image, focalPlane, toSample.getInverse(), ctrl)
+        afwMath.warpImage(norm, fpNorm, toSample.getInverse(), ctrl)
         image /= norm
 
         mask = afwImage.Mask(image.getBBox())

--- a/python/lsst/pipe/drivers/coaddDriver.py
+++ b/python/lsst/pipe/drivers/coaddDriver.py
@@ -204,7 +204,7 @@ class CoaddDriverTask(BatchPoolTask):
             ref = getDataRef(cache.butler, selectId, "calexp")
             self.log.info("Reading Wcs from %s" % (selectId,))
             md = ref.get("calexp_md", immediate=True)
-            wcs = afwImage.makeWcs(md)
+            wcs = afwGeom.makeSkyWcs(md)
             data = Struct(dataId=selectId, wcs=wcs, bbox=afwImage.bboxFromMetadata(md))
         except FitsError:
             self.log.warn("Unable to construct Wcs from %s" % (selectId,))


### PR DESCRIPTION
The transform direction changed in
warpImage(..., TransformPoint2Point2, ...) to match
the older warpImage(..., XYTransform, ...). Update accordingly.