### PR TITLE
DM-13741: fringe: disable re-estimation of the background

### DIFF
--- a/python/lsst/pipe/drivers/constructCalibs.py
+++ b/python/lsst/pipe/drivers/constructCalibs.py
@@ -1062,6 +1062,10 @@ class FringeConfig(CalibConfig):
     detectSigma = Field(dtype=float, default=1.0,
                         doc="Detection PSF gaussian sigma")
 
+    def setDefaults(self):
+        CalibConfig.setDefaults(self)
+        self.detection.reEstimateBackground = False
+
 
 class FringeTask(CalibTask):
     """Fringe construction task


### PR DESCRIPTION
Getting the background absolutely correct isn't important because we're
coadding lots of exposures, so little errors will get rejected. And
having two places where the background can be subtracted is potentially
confusing and/or dangerous.