### PR TITLE
DM-2639: {{Standardize primary method names, run/runDataRef, across PipeTasks}}

### DIFF
--- a/python/lsst/pipe/drivers/constructCalibs.py
+++ b/python/lsst/pipe/drivers/constructCalibs.py
@@ -359,10 +359,10 @@ class CalibTaskRunner(TaskRunner):
         task = self.TaskClass(config=self.config, log=self.log)
         exitStatus = 0                  # exit status for the shell
         if self.doRaise:
-            result = task.run(**args)
+            result = task.runDataRef(**args)
         else:
             try:
-                result = task.run(**args)
+                result = task.runDataRef(**args)
             except Exception as e:
                 exitStatus = 1          # n.b. The shell exit value is the number of dataRefs returning
                                         # non-zero, so the actual value used here is lost
@@ -416,7 +416,7 @@ class CalibTask(BatchPoolTask):
         kwargs.pop("doBatch", False)
         return CalibArgumentParser(calibName=cls.calibName, name=cls._DefaultName, *args, **kwargs)
 
-    def run(self, expRefList, butler, calibId):
+    def runDataRef(self, expRefList, butler, calibId):
         """!Construct a calib from a list of exposure references
 
         This is the entry point, called by the TaskRunner.__call__
@@ -442,7 +442,7 @@ class CalibTask(BatchPoolTask):
             dataId.update(outputIdItemList)
             self.addMissingKeys(dataId, butler)
             dataId.update(outputIdItemList)
-            
+
             try:
                 butler.get(self.calibName + "_filename", dataId)
             except Exception as e:

--- a/python/lsst/pipe/drivers/multiBandDriver.py
+++ b/python/lsst/pipe/drivers/multiBandDriver.py
@@ -199,7 +199,7 @@ class MultiBandDriverTask(BatchPoolTask):
         return time*numTargets/float(numCpus)
 
     @abortOnError
-    def run(self, patchRefList):
+    def runDataRef(self, patchRefList):
         """!Run multiband processing on coadds
 
         Only the master node runs this method.
@@ -346,7 +346,7 @@ class MultiBandDriverTask(BatchPoolTask):
                                  immediate=True)
             expId = int(patchRef.get(self.config.coaddName + "CoaddId"))
             self.detectCoaddSources.emptyMetadata()
-            detResults = self.detectCoaddSources.runDetection(coadd, idFactory, expId=expId)
+            detResults = self.detectCoaddSources.run(coadd, idFactory, expId=expId)
             self.detectCoaddSources.write(coadd, detResults, patchRef)
             self.detectCoaddSources.writeMetadata(patchRef)
 
@@ -366,7 +366,7 @@ class MultiBandDriverTask(BatchPoolTask):
                 self.log.info("Skipping mergeCoaddDetections for %s; output already exists." %
                               dataRefList[0].dataId)
                 return
-            self.mergeCoaddDetections.run(dataRefList)
+            self.mergeCoaddDetections.runDataRef(dataRefList)
 
     def runMeasureMerged(self, cache, dataId):
         """!Run measurement on a patch for a single filter
@@ -404,7 +404,7 @@ class MultiBandDriverTask(BatchPoolTask):
                               (numOldBig - numNewBig, dataRef.dataId))
                 reprocessing = True
 
-            self.measureCoaddSources.run(dataRef)
+            self.measureCoaddSources.runDataRef(dataRef)
             return reprocessing
 
     def runMergeMeasurements(self, cache, dataIdList):
@@ -424,7 +424,7 @@ class MultiBandDriverTask(BatchPoolTask):
                 self.log.info("Skipping mergeCoaddMeasurements for %s; output already exists" %
                               dataRefList[0].dataId)
                 return
-            self.mergeCoaddMeasurements.run(dataRefList)
+            self.mergeCoaddMeasurements.runDataRef(dataRefList)
 
     def runForcedPhot(self, cache, dataId):
         """!Run forced photometry on a patch for a single filter
@@ -442,7 +442,7 @@ class MultiBandDriverTask(BatchPoolTask):
                     dataRef.datasetExists(self.config.coaddName + "Coadd_forced_src", write=True)):
                 self.log.info("Skipping forcedPhotCoadd for %s; output already exists" % dataId)
                 return
-            self.forcedPhotCoadd.run(dataRef)
+            self.forcedPhotCoadd.runDataRef(dataRef)
 
     def writeMetadata(self, dataRef):
         """We don't collect any metadata, so skip"""

--- a/python/lsst/pipe/drivers/singleFrameDriver.py
+++ b/python/lsst/pipe/drivers/singleFrameDriver.py
@@ -60,7 +60,7 @@ class SingleFrameDriverTask(BatchParallelTask):
                                help="data ID, e.g. --id visit=12345 ccd=67")
         return parser
 
-    def run(self, sensorRef):
+    def runDataRef(self, sensorRef):
         """Process a single CCD, with scatter-gather-scatter using MPI.
         """
         if sensorRef.dataId[self.config.ccdKey] in self.ignoreCcds:
@@ -69,4 +69,4 @@ class SingleFrameDriverTask(BatchParallelTask):
             return None
 
         with self.logOperation("processing %s" % (sensorRef.dataId,)):
-            return self.processCcd.run(sensorRef)
+            return self.processCcd.runDataRef(sensorRef)

--- a/python/lsst/pipe/drivers/skyCorrection.py
+++ b/python/lsst/pipe/drivers/skyCorrection.py
@@ -95,7 +95,7 @@ class SkyCorrectionTask(BatchPoolTask):
         numTargets = len(cls.RunnerClass.getTargetList(parsedCmd))
         return time*numTargets
 
-    def run(self, expRef):
+    def runDataRef(self, expRef):
         """Perform sky correction on an exposure
 
         We restore the original sky, and remove it again using multiple

--- a/python/lsst/pipe/drivers/utils.py
+++ b/python/lsst/pipe/drivers/utils.py
@@ -10,7 +10,7 @@ class ButlerTaskRunner(TaskRunner):
     """Get a butler into the Task scripts"""
     @staticmethod
     def getTargetList(parsedCmd, **kwargs):
-        """Task.run should receive a butler in the kwargs"""
+        """Task.runDataRef should receive a butler in the kwargs"""
         return TaskRunner.getTargetList(parsedCmd, butler=parsedCmd.butler, **kwargs)
 
 

--- a/python/lsst/pipe/drivers/visualizeVisit.py
+++ b/python/lsst/pipe/drivers/visualizeVisit.py
@@ -106,7 +106,7 @@ class VisualizeVisitTask(BatchPoolTask):
         numTargets = len(cls.RunnerClass.getTargetList(parsedCmd))
         return time*numTargets
 
-    def run(self, expRef):
+    def runDataRef(self, expRef):
         """Generate an image of the entire visit
 
         Only the master node executes this method; it controls the slave nodes,


### PR DESCRIPTION
Rename methods according to RFC-352.
Fifteen total repositories with changes.
