### PR TITLE
Adapt calls to DetectCoaddSources' new API

### DIFF
--- a/python/lsst/pipe/drivers/coaddDriver.py
+++ b/python/lsst/pipe/drivers/coaddDriver.py
@@ -320,7 +320,7 @@ class CoaddDriverTask(BatchPoolTask):
                 # This includes background subtraction, so do it before writing
                 # the coadd
                 detResults = self.detectCoaddSources.run(coadd, idFactory, expId=expId)
-                self.detectCoaddSources.write(coadd, detResults, patchRef)
+                self.detectCoaddSources.write(detResults, patchRef)
         else:
             patchRef.put(coadd, self.assembleCoadd.config.coaddName+"Coadd")
 

--- a/python/lsst/pipe/drivers/multiBandDriver.py
+++ b/python/lsst/pipe/drivers/multiBandDriver.py
@@ -375,7 +375,7 @@ class MultiBandDriverTask(BatchPoolTask):
             expId = int(patchRef.get(self.config.coaddName + "CoaddId"))
             self.detectCoaddSources.emptyMetadata()
             detResults = self.detectCoaddSources.run(coadd, idFactory, expId=expId)
-            self.detectCoaddSources.write(coadd, detResults, patchRef)
+            self.detectCoaddSources.write(detResults, patchRef)
             self.detectCoaddSources.writeMetadata(patchRef)
 
     def runMergeDetections(self, cache, dataIdList):


### PR DESCRIPTION
The DetectCoaddSourcesTask.write() interface changed to support
its conversion to PipelineTask.