### PR TITLE
DM-17098: fix SkyMeasurementTask.measureScale

### DIFF
--- a/python/lsst/pipe/drivers/background.py
+++ b/python/lsst/pipe/drivers/background.py
@@ -284,7 +284,10 @@ class SkyMeasurementTask(Task):
         statistic = afwMath.stringToStatisticsProperty(self.config.stats.statistic)
         imageSamples = []
         skySamples = []
-        for xStart, yStart, xStop, yStop in zip(xLimits[:-1], yLimits[:-1], xLimits[1:], yLimits[1:]):
+        for xIndex, yIndex in itertools.product(range(self.config.xNumSamples),
+                                                range(self.config.yNumSamples)):
+            xStart, xStop = xLimits[xIndex], xLimits[xIndex + 1]
+            yStart, yStop = yLimits[yIndex], yLimits[yIndex + 1]
             box = afwGeom.Box2I(afwGeom.Point2I(xStart, yStart), afwGeom.Point2I(xStop, yStop))
             subImage = image.Factory(image, box)
             subSky = sky.Factory(sky, box)


### PR DESCRIPTION
SkyMeasurementTask.measureScale uses zip to iterate over x and y
limits, so it's only iterating over the diagonal of the image.
Using itertools.product, we iterate over the entire image.