### PR TITLE
DM-19907: Pad numerator image by 1 instead of 0

### DIFF
--- a/python/lsst/pipe/drivers/background.py
+++ b/python/lsst/pipe/drivers/background.py
@@ -867,6 +867,5 @@ def smoothArray(array, bad, sigma):
         Smoothed image.
     """
     convolved = gaussian_filter(numpy.where(bad, 0.0, array), sigma, mode="constant", cval=0.0)
-    numerator = gaussian_filter(numpy.ones_like(array), sigma, mode="constant", cval=0.0)
     denominator = gaussian_filter(numpy.where(bad, 0.0, 1.0), sigma, mode="constant", cval=0.0)
-    return convolved*numerator/denominator
+    return convolved/denominator


### PR DESCRIPTION
All pixels in the new numberator image are 1.0, and multiplying
with the convolved image has no effect.