### PR TITLE
Fix PBS walltime calculation in constructCalibs.py

### DIFF
--- a/python/lsst/pipe/drivers/constructCalibs.py
+++ b/python/lsst/pipe/drivers/constructCalibs.py
@@ -415,8 +415,8 @@ class CalibTask(BatchPoolTask):
         numCcds = len(parsedCmd.butler.get("camera"))
         numExps = len(cls.RunnerClass.getTargetList(
             parsedCmd)[0]['expRefList'])
-        numCycles = int(numCcds/float(numCores) + 0.5)
-        return time*numExps*numCycles
+        numCycles = int(numCcds*numExps/float(numCores) + 0.5)
+        return time*numCycles
 
     @classmethod
     def _makeArgumentParser(cls, *args, **kwargs):


### PR DESCRIPTION
`constructCalibs.py` erroneously gives zero walltime when the number of cores used exceeds the number of chips that are to be processed. The associated issue was reported on the LSST community support page [here](https://community.lsst.org/t/batchwalltime-in-constructcalibs-py/3761).