### PR TITLE
Adjust batchWallTime in case numCcds < numCores

### DIFF
--- a/python/lsst/pipe/drivers/constructCalibs.py
+++ b/python/lsst/pipe/drivers/constructCalibs.py
@@ -411,8 +411,8 @@ class CalibTask(BatchPoolTask):
         numCcds = len(parsedCmd.butler.get("camera"))
         numExps = len(cls.RunnerClass.getTargetList(
             parsedCmd)[0]['expRefList'])
-        numCycles = int(numCcds/float(numCores) + 0.5)
-        return time*numExps*numCycles
+        numCycles = int(numExps*numCcds/float(numCores) + 0.5)
+        return time*numCycles
 
     @classmethod
     def _makeArgumentParser(cls, *args, **kwargs):


### PR DESCRIPTION
In case `numCcds < numCores`, `batchWallTime` in flatTask returns zero, because `numCycles` becomes zero. The change makes the task resistant to the case `numCcds<numCores`.