### PR TITLE
DM-29055: Update Connections in SkyCorrectionTask

### DIFF
--- a/python/lsst/pipe/drivers/skyCorrection.py
+++ b/python/lsst/pipe/drivers/skyCorrection.py
@@ -23,6 +23,7 @@ import lsst.afw.image as afwImage
 import lsst.pipe.base as pipeBase
 
 from lsst.pipe.base import ArgumentParser, ConfigDatasetType
+from lsst.daf.butler import DimensionGraph
 from lsst.pex.config import Config, Field, ConfigurableField, ConfigField
 from lsst.ctrl.pool.pool import Pool
 from lsst.ctrl.pool.parallel import BatchPoolTask
@@ -56,13 +57,43 @@ def makeCameraImage(camera, exposures, filename=None, binning=8):
     return image
 
 
+def _skyLookup(datasetType, registry, quantumDataId, collections):
+    """Lookup function to identify sky frames
+
+    Parameters
+    ----------
+    datasetType : `lsst.daf.butler.DatasetType`
+        Dataset to lookup.
+    registry : `lsst.daf.butler.Registry`
+        Butler registry to query.
+    quantumDataId : `lsst.daf.butler.DataCoordinate`
+        Data id to transform to find sky frames.
+        The ``detector`` entry will be stripped.
+    collections : `lsst.daf.butler.CollectionSearch`
+        Collections to search through.
+
+    Returns
+    -------
+    results : `list` [`lsst.daf.butler.DatasetRef`]
+        List of datasets that will be used as sky calibration frames
+    """
+    newDataId = quantumDataId.subset(DimensionGraph(registry.dimensions, names=["instrument", "visit"]))
+    skyFrames = []
+    for dataId in registry.queryDataIds(["visit", "detector"], dataId=newDataId).expanded():
+        skyFrame = registry.findDataset(datasetType, dataId, collections=collections,
+                                        timespan=dataId.timespan)
+        skyFrames.append(skyFrame)
+
+    return skyFrames
+
+
 class SkyCorrectionConnections(pipeBase.PipelineTaskConnections, dimensions=("instrument", "visit")):
     rawLinker = cT.Input(
         doc="Raw data to provide exp-visit linkage to connect calExp inputs to camera/sky calibs.",
         name="raw",
         multiple=True,
         deferLoad=True,
-        storageClass="ExposureU",
+        storageClass="Exposure",
         dimensions=["instrument", "exposure", "detector"],
     )
     calExpArray = cT.Input(
@@ -83,14 +114,17 @@ class SkyCorrectionConnections(pipeBase.PipelineTaskConnections, dimensions=("in
         doc="Input camera to use.",
         name="camera",
         storageClass="Camera",
-        dimensions=["instrument", "calibration_label"],
+        dimensions=["instrument"],
+        isCalibration=True,
     )
     skyCalibs = cT.PrerequisiteInput(
         doc="Input sky calibrations to use.",
         name="sky",
         multiple=True,
         storageClass="ExposureF",
-        dimensions=["instrument", "physical_filter", "detector", "calibration_label"],
+        dimensions=["instrument", "physical_filter", "detector"],
+        isCalibration=True,
+        lookupFunction=_skyLookup,
     )
     calExpCamera = cT.Output(
         doc="Output camera image.",


### PR DESCRIPTION
for changed gen3 interface:
- storage class for raws
- calibration_label not in use anymore
- need lookup function as workaround for inability to query
  calibration collections