### PR TITLE
DM-19852: Add deprecation messages around classes that have moved to pipe_tasks

### DIFF
--- a/python/lsst/pipe/drivers/background.py
+++ b/python/lsst/pipe/drivers/background.py
@@ -1,6 +1,7 @@
 import numpy
 import itertools
 from scipy.ndimage import gaussian_filter
+from deprecated.sphinx import deprecated
 
 import lsst.afw.math as afwMath
 import lsst.afw.image as afwImage
@@ -479,6 +480,12 @@ class FocalPlaneBackgroundConfig(Config):
     binning = Field(dtype=int, default=64, doc="Binning to use for CCD background model (pixels)")
 
 
+@deprecated(
+    reason="pipe_drivers is deprecated. It will be removed after v25. "
+    "Please use lsst.pipe.tasks.background.FocalPlaneBackground instead.",
+    version="v25.0",
+    category=FutureWarning,
+)
 class FocalPlaneBackground:
     """Background model for a focal plane camera
 

--- a/python/lsst/pipe/drivers/skyCorrection.py
+++ b/python/lsst/pipe/drivers/skyCorrection.py
@@ -18,6 +18,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from deprecated.sphinx import deprecated
+
 import lsst.afw.math as afwMath
 import lsst.afw.image as afwImage
 import lsst.pipe.base as pipeBase
@@ -194,6 +197,12 @@ class SkyCorrectionConfig(pipeBase.PipelineTaskConfig, pipelineConnections=SkyCo
         self.bgModel2.smoothScale = 1.0
 
 
+@deprecated(
+    reason="pipe_drivers is deprecated. It will be removed after v25. "
+    "Please use lsst.pipe.tasks.skyCorrection.SkyCorrectionTask instead.",
+    version="v25.0",
+    category=FutureWarning,
+)
 class SkyCorrectionTask(pipeBase.PipelineTask, BatchPoolTask):
     """Correct sky over entire focal plane"""
     ConfigClass = SkyCorrectionConfig


### PR DESCRIPTION
I've only added the deprecation message to the two classes that were used by our pipeline code.