### PR TITLE
DM-35917: Allow gen3 SkyCorrectionTask to be imported without gen2

### DIFF
--- a/python/lsst/pipe/drivers/skyCorrection.py
+++ b/python/lsst/pipe/drivers/skyCorrection.py
@@ -25,15 +25,34 @@ import lsst.afw.math as afwMath
 import lsst.afw.image as afwImage
 import lsst.pipe.base as pipeBase
 
-from lsst.pipe.base import ArgumentParser, ConfigDatasetType
 from lsst.daf.butler import DimensionGraph
 from lsst.pex.config import Config, Field, ConfigurableField, ConfigField
-from lsst.ctrl.pool.pool import Pool
-from lsst.ctrl.pool.parallel import BatchPoolTask
 from lsst.pipe.drivers.background import (SkyMeasurementTask, FocalPlaneBackground,
                                           FocalPlaneBackgroundConfig, MaskObjectsTask)
 import lsst.pipe.drivers.visualizeVisit as visualizeVisit
 import lsst.pipe.base.connectionTypes as cT
+
+try:
+    from lsst.pipe.base import ArgumentParser
+    from lsst.pipe.base import ConfigDatasetType
+
+except ImportError:
+    from argparse import ArgumentParser
+
+    class ConfigDatasetType:
+        def __init__(**kwargs):
+            raise NotImplementedError()
+
+try:
+    from lsst.ctrl.pool.pool import Pool
+except ImportError:
+    class Pool:
+        pass
+
+try:
+    from lsst.ctrl.pool.parallel import BatchPoolTask
+except ImportError:
+    from lsst.pipe.base import Task as BatchPoolTask
 
 __all__ = ["SkyCorrectionConfig", "SkyCorrectionTask"]
 

--- a/python/lsst/pipe/drivers/visualizeVisit.py
+++ b/python/lsst/pipe/drivers/visualizeVisit.py
@@ -4,10 +4,25 @@ import lsst.afw.math as afwMath
 import lsst.afw.image as afwImage
 
 from lsst.afw.cameraGeom.utils import makeImageFromCamera
-from lsst.pipe.base import ArgumentParser
+
 from lsst.pex.config import Config, Field
-from lsst.ctrl.pool.pool import Pool
-from lsst.ctrl.pool.parallel import BatchPoolTask
+
+# Allow imports for gen3 code paths.
+try:
+    from lsst.pipe.base import ArgumentParser
+except ImportError:
+    from argparse import ArgumentParser
+
+try:
+    from lsst.ctrl.pool.pool import Pool
+except ImportError:
+    class Pool:
+        pass
+
+try:
+    from lsst.ctrl.pool.parallel import BatchPoolTask
+except ImportError:
+    from lsst.pipe.base import Task as BatchPoolTask
 
 
 def makeCameraImage(camera, exposures, binning):


### PR DESCRIPTION
Gen2 classes will be loaded if available.